### PR TITLE
chore(deps): update 1 dependency (24h cooloff)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup Docker BuildX
         id: setup-buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           install: true
           driver-opts: network=host


### PR DESCRIPTION
## Summary
- Ran a full 24h-cooloff sweep across the repo (`scan-deps` + `batch`, one concurrent pass). No package manifests exist in this repo (Docker-action only); scope was the four GitHub Actions referenced under `.github/workflows`.
- Three of the four actions (`actions/checkout@v7.0.1`, `docker/build-push-action@v7.3.0`, `super-linter/super-linter@v8.7.0`) were already pinned to the correct, cooloff-cleared SHA — left untouched.
- Bumped `docker/setup-buildx-action` from `v4.2.0` to `v4.3.0`, re-pinned to the new commit SHA.

| Action | Old -> New | Published | Age at check |
|---|---|---|---|
| docker/setup-buildx-action | v4.2.0 -> v4.3.0 | 2026-08-19T09:41:47Z | ~74h |

## Held back
None — every resolved target for this repo was already clear of the 24h window.

## Notes / manual checks
- `scan-deps` produced no `note:` entries (nothing unparsed).
- No `package.json`, `requirements*.txt`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `Gemfile`, or `pom.xml` present, so no lockfile regeneration was applicable.

## Major bumps
None (patch bump only, no breaking changes expected per docker/setup-buildx-action releases).

## Verification
- Validated `.github/workflows/ci.yml` parses as YAML (`yaml.safe_load`).
- No test suite / build present in this repo to run beyond the workflow itself (this repo's CI is exercised by GitHub Actions on push/PR).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>